### PR TITLE
handle condition: ttl is not always present

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -780,7 +780,10 @@ impl InsertableName {
         let _name_hash = super::hashing::get_name_id(&_name).unwrap(); // TODO
         let _tx_hash = transaction.hash.clone();
         let _account_id = transaction.tx["account_id"].as_str()?;
-        let _expires_at = transaction.tx["ttl"].as_i64()? + transaction.block_height as i64;
+        let _expires_at = match transaction.tx["ttl"].as_i64() {
+            Some(_ttl) => { _ttl + transaction.block_height as i64 },
+            _ => { 0 }
+        };
         Some(InsertableName::new(
             &_name.to_string(),
             &_name_hash,


### PR DESCRIPTION
If the `ttl` is 0(zero) the node removes it from the API response.