### PR TITLE
remove the default value for verify

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -635,7 +635,7 @@ impl BlockLoader {
     pub fn verify_height(&self, _height: i64) -> MiddlewareResult<()>{
         let conn = PGCONNECTION.get()?;
         match self.compare_chain_and_db(_height, &conn) {
-            Ok(_) => println!("Height {} OK", _height),
+            Ok(_val) => println!("Height {} OK {}", _height, _val),
             Err(e) => println!("Height {} not OK: {}", _height, match e.to_string().lines().next() { Some(x) => x, None => "", }),
         }
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,15 +198,15 @@ fn main() {
     if verify {
         debug!("Verifying");
         let loader = BlockLoader::new(url.clone());
-        let to_verify = range(&String::from(matches.value_of("verify").unwrap()));
-        if to_verify == vec!(0) {
+        let verify_flags = String::from(matches.value_of("verify").unwrap()).to_lowercase();
+        if &verify_flags == "all" {
             match loader.verify_all() {
                 Ok(_) => (),
                 Err(x) => error!("Blockloader::verify() returned an error: {}", x),
             };
             return;
         } else {
-            for height in to_verify {
+            for height in range(&verify_flags) {
                 loader.verify_height(height);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,8 +155,7 @@ fn main() {
                 .short("v")
                 .long("verify")
                 .help("Verify DB integrity against chain")
-                .takes_value(true)
-                .default_value("0") // special value, yuck
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("heights")


### PR DESCRIPTION
adding a default value sets the flag to true(present) by default even if the user does not provides it.